### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -52,8 +52,8 @@ def load_tests(loader, tests, pattern):
 
     for f in example_filesnames:
         testname = 'test_' + f[:-3]
-        expected_output = open('tests/examples_output/%s.template' %
-                               f[:-3]).read()
+        expected_output = open('tests/examples_output/{0!s}.template'.format(
+                               f[:-3])).read()
         test_class = create_test_class(testname, filename=examples + '/' + f,
                                        expected_output=expected_output)
         tests = loader.loadTestsFromTestCase(test_class)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -89,9 +89,9 @@ class TestValidators(unittest.TestCase):
                 iam_names(s)
 
     def test_iam_path(self):
-        for s in ['/%s/' % ('a'*30), '/%s/' % ('a'*510)]:
+        for s in ['/{0!s}/'.format(('a'*30)), '/{0!s}/'.format(('a'*510))]:
             iam_path(s)
-        for s in ['/%s/' % ('a'*511), '/%s/' % ('a'*1025)]:
+        for s in ['/{0!s}/'.format(('a'*511)), '/{0!s}/'.format(('a'*1025))]:
             with self.assertRaises(ValueError):
                 iam_path(s)
 

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -144,11 +144,10 @@ class BaseAWSObject(object):
             # validation. The properties of a CustomResource is not known.
             return self.properties.__setitem__(name, value)
 
-        raise AttributeError("%s object does not support attribute %s" %
-                             (type_name, name))
+        raise AttributeError("{0!s} object does not support attribute {1!s}".format(type_name, name))
 
     def _raise_type(self, name, value, expected_type):
-        raise TypeError('%s: %s.%s is %s, expected %s' % (self.__class__,
+        raise TypeError('{0!s}: {1!s}.{2!s} is {3!s}, expected {4!s}'.format(self.__class__,
                                                           self.title,
                                                           name,
                                                           type(value),
@@ -156,7 +155,7 @@ class BaseAWSObject(object):
 
     def validate_title(self):
         if not valid_names.match(self.title):
-            raise ValueError('Name "%s" not alphanumeric' % self.title)
+            raise ValueError('Name "{0!s}" not alphanumeric'.format(self.title))
 
     def validate(self):
         pass
@@ -172,7 +171,7 @@ class BaseAWSObject(object):
             if required and k not in self.properties:
                 rtype = getattr(self, 'resource_type', "<unknown type>")
                 raise ValueError(
-                    "Resource %s required in type %s" % (k, rtype))
+                    "Resource {0!s} required in type {1!s}".format(k, rtype))
         self.validate()
         # Mainly used to not have an empty "Properties".
         if self.properties:
@@ -416,7 +415,7 @@ class Template(object):
         self.conditions[name] = condition
 
     def handle_duplicate_key(self, key):
-        raise ValueError('duplicate key "%s" detected' % key)
+        raise ValueError('duplicate key "{0!s}" detected'.format(key))
 
     def _update(self, d, values):
         if isinstance(values, list):

--- a/troposphere/cloudformation.py
+++ b/troposphere/cloudformation.py
@@ -148,7 +148,7 @@ class InitConfig(AWSProperty):
 def validate_authentication_type(auth_type):
     valid_types = ['S3', 'basic']
     if auth_type not in valid_types:
-        raise ValueError('Type needs to be one of %r' % valid_types)
+        raise ValueError('Type needs to be one of {0!r}'.format(valid_types))
     return auth_type
 
 

--- a/troposphere/dynamodb2.py
+++ b/troposphere/dynamodb2.py
@@ -9,23 +9,23 @@ from . import AWSObject, AWSProperty
 def attribute_type_validator(x):
     valid_types = ["S", "N", "B"]
     if x not in valid_types:
-        raise ValueError("AttributeType must be one of: %s" %
-                         valid_types.join(", "))
+        raise ValueError("AttributeType must be one of: {0!s}".format(
+                         valid_types.join(", ")))
     return x
 
 
 def key_type_validator(x):
     valid_types = ["HASH", "RANGE"]
     if x not in valid_types:
-        raise ValueError("KeyType must be one of: %s" % valid_types.join(", "))
+        raise ValueError("KeyType must be one of: {0!s}".format(valid_types.join(", ")))
     return x
 
 
 def projection_type_validator(x):
     valid_types = ["KEYS_ONLY", "INCLUDE", "ALL"]
     if x not in valid_types:
-        raise ValueError("ProjectionType must be one of: %s" %
-                         valid_types.join(", "))
+        raise ValueError("ProjectionType must be one of: {0!s}".format(
+                         valid_types.join(", ")))
     return x
 
 

--- a/troposphere/elasticbeanstalk.py
+++ b/troposphere/elasticbeanstalk.py
@@ -69,14 +69,14 @@ class ConfigurationTemplate(AWSObject):
 def validate_tier_name(name):
     valid_names = [WebServer, Worker]
     if name not in valid_names:
-        raise ValueError('Tier name needs to be one of %r' % valid_names)
+        raise ValueError('Tier name needs to be one of {0!r}'.format(valid_names))
     return name
 
 
 def validate_tier_type(tier_type):
     valid_types = [WebServerType, WorkerType]
     if tier_type not in valid_types:
-        raise ValueError('Tier type needs to be one of %r' % valid_types)
+        raise ValueError('Tier type needs to be one of {0!r}'.format(valid_types))
     return tier_type
 
 

--- a/troposphere/elasticsearch.py
+++ b/troposphere/elasticsearch.py
@@ -18,8 +18,8 @@ except ImportError:
 def validate_volume_type(volume_type):
     """Validate VolumeType for ElasticsearchDomain"""
     if volume_type not in VALID_VOLUME_TYPES:
-        raise ValueError("Elasticsearch Domain VolumeType must be one of: %s" %
-                         ", ".join(VALID_VOLUME_TYPES))
+        raise ValueError("Elasticsearch Domain VolumeType must be one of: {0!s}".format(
+                         ", ".join(VALID_VOLUME_TYPES)))
     return volume_type
 
 

--- a/troposphere/emr.py
+++ b/troposphere/emr.py
@@ -86,8 +86,8 @@ class Configuration(AWSProperty):
 def market_validator(x):
     valid_values = ['ON_DEMAND', 'SPOT']
     if x not in valid_values:
-        raise ValueError("Market must be one of: %s" %
-                         ', '.join(valid_values))
+        raise ValueError("Market must be one of: {0!s}".format(
+                         ', '.join(valid_values)))
     return x
 
 
@@ -170,8 +170,8 @@ class HadoopJarStepConfig(AWSProperty):
 def action_on_failure_validator(x):
     valid_values = ['CONTINUE', 'CONTINUE_AND_WAIT']
     if x not in valid_values:
-        raise ValueError("ActionOnFailure must be one of: %s" %
-                         ', '.join(valid_values))
+        raise ValueError("ActionOnFailure must be one of: {0!s}".format(
+                         ', '.join(valid_values)))
     return x
 
 

--- a/troposphere/opsworks.py
+++ b/troposphere/opsworks.py
@@ -46,7 +46,7 @@ class Recipes(AWSProperty):
 def validate_volume_type(volume_type):
     volume_types = ('standard', 'io1', 'gp2')
     if volume_type not in volume_types:
-        raise ValueError("VolumeType (given: %s) must be one of: %s" % (
+        raise ValueError("VolumeType (given: {0!s}) must be one of: {1!s}".format(
             volume_type, ', '.join(volume_types)))
     return volume_type
 

--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -34,8 +34,8 @@ def validate_storage_type(storage_type):
     """Validate StorageType for DBInstance"""
 
     if storage_type not in VALID_STORAGE_TYPES:
-        raise ValueError("DBInstance StorageType must be one of: %s" %
-                         ", ".join(VALID_STORAGE_TYPES))
+        raise ValueError("DBInstance StorageType must be one of: {0!s}".format(
+                         ", ".join(VALID_STORAGE_TYPES)))
     return storage_type
 
 
@@ -43,8 +43,8 @@ def validate_engine(engine):
     """Validate database Engine for DBInstance """
 
     if engine not in VALID_DB_ENGINES:
-        raise ValueError("DBInstance Engine must be one of: %s" %
-                         ", ".join(VALID_DB_ENGINES))
+        raise ValueError("DBInstance Engine must be one of: {0!s}".format(
+                         ", ".join(VALID_DB_ENGINES)))
     return engine
 
 
@@ -52,8 +52,8 @@ def validate_license_model(license_model):
     """Validate LicenseModel for DBInstance"""
 
     if license_model not in VALID_LICENSE_MODELS:
-        raise ValueError("DBInstance LicenseModel must be one of: %s" %
-                         ", ".join(VALID_LICENSE_MODELS))
+        raise ValueError("DBInstance LicenseModel must be one of: {0!s}".format(
+                         ", ".join(VALID_LICENSE_MODELS)))
     return license_model
 
 

--- a/troposphere/s3.py
+++ b/troposphere/s3.py
@@ -223,8 +223,8 @@ class Bucket(AWSObject):
 
         if 'AccessControl' in kwargs:
             if kwargs['AccessControl'] not in self.access_control_types:
-                raise ValueError('AccessControl must be one of "%s"' % (
-                    ', '.join(self.access_control_types)))
+                raise ValueError('AccessControl must be one of "{0!s}"'.format((
+                    ', '.join(self.access_control_types))))
 
 
 class BucketPolicy(AWSObject):

--- a/troposphere/utils.py
+++ b/troposphere/utils.py
@@ -2,7 +2,7 @@ import time
 
 
 def _tail_print(e):
-    print("%s %s %s" % (e.resource_status, e.resource_type, e.event_id))
+    print("{0!s} {1!s} {2!s}".format(e.resource_status, e.resource_type, e.event_id))
 
 
 def get_events(conn, stackname):

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -17,7 +17,7 @@ def integer(x):
     try:
         int(x)
     except (ValueError, TypeError):
-        raise ValueError("%r is not a valid integer" % x)
+        raise ValueError("{0!r} is not a valid integer".format(x))
     else:
         return x
 
@@ -25,7 +25,7 @@ def integer(x):
 def positive_integer(x):
     p = integer(x)
     if int(p) < 0:
-        raise ValueError("%r is not a positive integer" % x)
+        raise ValueError("{0!r} is not a positive integer".format(x))
     return x
 
 
@@ -33,7 +33,7 @@ def integer_range(minimum_val, maximum_val):
     def integer_range_checker(x):
         i = int(x)
         if i < minimum_val or i > maximum_val:
-            raise ValueError('Integer must be between %d and %d' % (
+            raise ValueError('Integer must be between {0:d} and {1:d}'.format(
                 minimum_val, maximum_val))
         return x
 
@@ -49,7 +49,7 @@ def network_port(x):
 
     i = integer(x)
     if int(i) < -1 or int(i) > 65535:
-        raise ValueError("network port %r must been between 0 and 65535" % i)
+        raise ValueError("network port {0!r} must been between 0 and 65535".format(i))
     return x
 
 
@@ -58,20 +58,20 @@ def s3_bucket_name(b):
     if s3_bucket_name_re.match(b):
         return b
     else:
-        raise ValueError("%s is not a valid s3 bucket name" % b)
+        raise ValueError("{0!s} is not a valid s3 bucket name".format(b))
 
 
 def encoding(encoding):
     valid_encodings = ['plain', 'base64']
     if encoding not in valid_encodings:
-        raise ValueError('Encoding needs to be one of %r' % valid_encodings)
+        raise ValueError('Encoding needs to be one of {0!r}'.format(valid_encodings))
     return encoding
 
 
 def status(status):
     valid_statuses = ['Active', 'Inactive']
     if status not in valid_statuses:
-        raise ValueError('Status needs to be one of %r' % valid_statuses)
+        raise ValueError('Status needs to be one of {0!r}'.format(valid_statuses))
     return status
 
 
@@ -80,7 +80,7 @@ def iam_names(b):
     if iam_name_re.match(b):
         return b
     else:
-        raise ValueError("%s is not a valid iam name" % b)
+        raise ValueError("{0!s} is not a valid iam name".format(b))
 
 
 def iam_path(path):
@@ -89,7 +89,7 @@ def iam_path(path):
 
     iam_path_re = compile(r'^\/.*\/$|^\/$')
     if not iam_path_re.match(path):
-        raise ValueError("%s is not a valid iam path name" % path)
+        raise ValueError("{0!s} is not a valid iam path name".format(path))
     return path
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:troposphere?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:troposphere?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
